### PR TITLE
Re-enable fetch test now that server is up

### DIFF
--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -397,12 +397,10 @@ function sendTelemetry(payload) {
 }
 
 async function fetchTest() {
-    /*
-      TODO(ekr@rtfm.com): the test page is down. Uncomment this.
 
     let responseText = null;
     try {
-        response = await fetch("https://dnssec-experiment-moz.net/", {cache: "no-store"});
+        const response = await fetch("https://dnssec-experiment-moz.net/", {cache: "no-store"});
         responseText = await response.text();
     } catch(e) {
         sendTelemetry({reason: STUDY_ERROR_FETCH_FAILED});
@@ -412,7 +410,6 @@ async function fetchTest() {
         sendTelemetry({reason: STUDY_ERROR_FETCH_NOT_MATCHED});
         throw new Error(STUDY_ERROR_FETCH_NOT_MATCHED);
     }
-   */
 }
 
 /**


### PR DESCRIPTION
Some of the DNS records still need to be updated, but the fetch tests works now.