### PR TITLE
Fix dependency import race conditions

### DIFF
--- a/src/experiments/resolvconf/api.js
+++ b/src/experiments/resolvconf/api.js
@@ -2,22 +2,34 @@
 /* exported resolvconf */
 /* global ChromeUtils, ExtensionAPI, Cc, Ci, */
 
-const { OS } = ChromeUtils.import("resource://gre/modules/osfile.jsm");
-const { ExtensionUtils } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionUtils.jsm"
-);
-const { ExtensionError } = ExtensionUtils;
-
-const MAC_RESOLVCONF_PATH = "/etc/resolv.conf";
-const STUDY_ERROR_NAMESERVERS_FILE = "STUDY_ERROR_NAMESERVERS_FILE";
+/** Warning!!
+ *  You shouldn't declare anything in the global scope, which is shared with other api.js from the same privileged extension.
+ *  See https://firefox-source-docs.mozilla.org/toolkit/components/extensions/webextensions/basics.html#globals-available-in-the-api-scripts-global
+ */
 
 var resolvconf = class resolvconf extends ExtensionAPI {
+    static MAC_RESOLVCONF_PATH = "/etc/resolv.conf";
+    static STUDY_ERROR_NAMESERVERS_FILE = "STUDY_ERROR_NAMESERVERS_FILE";
+
+    constructor(...args) {
+        super(...args);
+        ChromeUtils.defineModuleGetter(this, "OS", "resource://gre/modules/osfile.jsm");
+    }
+
     getAPI(context) {
+        const {
+            MAC_RESOLVCONF_PATH,
+            STUDY_ERROR_NAMESERVERS_FILE
+        } = resolvconf;
+
+        const { ExtensionError } = ExtensionUtils;
+        const { OS } = this;
+
         return {
             experiments: {
                 resolvconf: {
                     /**
-                     * If a client is on macOS, read nameservers from 
+                     * If a client is on macOS, read nameservers from
                      * /etc/resolv.conf
                      */
                     async readNameserversMac() {


### PR DESCRIPTION
Due to a behavior on the add-ons side where privileged apis are loaded into the same scope (see [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1697404#c3)), calls to `setTimeout` will sometimes fail if they're sent early enough.

At a high level, the fix here is to (1) make sure that `setTimeout` is imported in both `api.js` files, and (2) that we aren't declaring anything in the global scope (which could cause non-deterministic conflicts). More specifically, I assign imports to the `class` instance in the constructor, and to move variables to static properties, with a warning about the  shared scope behavior in comments.

So for example, this:

```js
const FOO = "FOO";
const { setTimeout } = ChromeUtils.import("resource://gre/modules/Timer.jsm");
class Example {
  getAPI() {
    setTimeout(() => console.log(FOO), 100);  
  }
}
```
becomes this:
```js
const FOO = "FOO";
const { setTimeout } = ChromeUtils.import("resource://gre/modules/Timer.jsm");
class Example {
  static FOO = "FOO";
  constructor() {
    // Assigns setTimeout to this.setTimeout
    ChromeUtils.defineModuleGetter(this, "setTimeout", "resource://gre/modules/Timer.jsm");
  }

  getAPI() {
    this.setTimeout(() => console.log(Example.FOO), 100);  
  }
}
```

### STR
Try reloading the add-on a few times. Eventually you will see the following error in the add-on console:

![image](https://user-images.githubusercontent.com/1455535/199577160-0ce42c02-2192-429c-9b13-e8cd82e73756.png)

which is caused by this `setTimeout is not defined` error from experiments/tcpsocket/api.js:

![image](https://user-images.githubusercontent.com/1455535/199577369-f9bdaf7d-6230-4db9-9dbc-b372fe07b38f.png)
