### PR TITLE
Update domain configuration

### DIFF
--- a/test/dns-test.test.js
+++ b/test/dns-test.test.js
@@ -16,7 +16,8 @@ const {
     STUDY_START,
     STUDY_MEASUREMENT_COMPLETED,
     COMMON_QUERIES,
-    EXPECTED_FETCH_RESPONSE
+    EXPECTED_FETCH_RESPONSE,
+    SMIMEA_HASH
 } = require("../src/dns-test");
 const { assert } = require("chai");
 const sinon = require("sinon");
@@ -72,9 +73,13 @@ const EXPECTED_QUERY_CHECK = [
 
     // HTTPS records should have a prefix
     ["tcp", "tcp-HTTPS", "httpssvc.dnssec-experiment-moz.net"],
-    ["tcp", "tcp-HTTPS-U", `httpssvc.tcp-HTTPS-U-${FAKE_UUID}.pc.dnssec-experiment-moz.net`],
+    ["tcp", "tcp-HTTPS-U", `tcp-HTTPS-U-${FAKE_UUID}.httpssvc-pc.dnssec-experiment-moz.net`],
     ["udp", "udp-HTTPS", "httpssvc.dnssec-experiment-moz.net"],
-    ["udp", "udp-HTTPS-U", `httpssvc.udp-HTTPS-U-${FAKE_UUID}.pc.dnssec-experiment-moz.net`],
+    ["udp", "udp-HTTPS-U", `udp-HTTPS-U-${FAKE_UUID}.httpssvc-pc.dnssec-experiment-moz.net`],
+
+    // SMIMEA records should have the right SMIMEA structure
+    ["tcp", "tcp-SMIMEA", SMIMEA_HASH + "._smimecert.dnssec-experiment-moz.net"],
+    ["udp", "udp-SMIMEA-U", `udp-SMIMEA-U-${FAKE_UUID}._smimecert.pc.dnssec-experiment-moz.net`],
 ];
 
 function mockFetch(url, text) {


### PR DESCRIPTION
This patch updates the expected per-client domain structure of `HTTPS` and `SMIMEA` records. Where the uuid is `k88`:
* A tcp query for HTTPS per-client record would be `tcp-HTTPS-U-k88.httpssvc-pc.httpssvc-pc.dnssec-experiment-moz.net`
* A udp query for a SMIMEA per-client record would be `udp-SMIMEA-U-k88._smimecert.pc.dnssec-experiment-moz.net` (note that on master, the prefix is actually missing the `_smimecert`part which is required as per the spec

A few things I'm not sure about:
* According to https://datatracker.ietf.org/doc/rfc8162/ the part to the left of `._smimecert` is supposed to be hashed, not sure how important that is
* Not sure if using the `pc` subdomain is ok for the SMIMEA record. It appears to be working when I test it. I could instead just configure a single wildcard, like `*._smimecert`
* There's some problem with DNSSEC configuration for `*.pc` and `*.httpssvc-pc`: The UI is telling me "this hostname is not covered by a certificate". The A and HTTPS records appear to be working fine
* I can't figure out how to configure NEWONE, NEWTWO, etc. records

I've updated the live DNS configuration as follows:
![image](https://user-images.githubusercontent.com/1455535/200988288-b5fc1b88-d730-4bc4-8ed2-bdbab8df6fe2.png)

