### PR TITLE
Remove RRSIG query, add DS

### DIFF
--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -30,7 +30,7 @@ const COMMON_QUERIES = [
     { rrtype: "A", dnssec_ok: true },
     { rrtype: "A", dnssec_ok: true, checking_disabled: true },
     { rrtype: "DNSKEY", dnssec_ok: true },
-    { rrtype: "RRSIG"},
+    { rrtype: "DS"},
     { rrtype: "NEWONE"},
     { rrtype: "NEWTWO"},
     { rrtype: "NEWTHREE"},

--- a/test/dns-test.test.js
+++ b/test/dns-test.test.js
@@ -44,7 +44,7 @@ const ALL_KEY_TYPES = [
     "ACD",
     "ADOCD",
     "DNSKEYDO",
-    "RRSIG",
+    "DS",
     "NEWONE",
     "NEWTWO",
     "NEWTHREE",


### PR DESCRIPTION
As expected the DS queries for `dnssec-experiment-moz.net`are getting a response, the per-client queries are not.