### PR TITLE
Send query-related errors with the final payload, validate against the data pipeline schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
         "web-ext": "^6.5.0"
       },
       "devDependencies": {
+        "ajv": "^5.5.2",
         "chai": "^4.3.6",
+        "chai-json-schema-ajv": "^5.2.4",
         "eslint": "^7.6.0",
         "mocha": "^10.1.0",
         "node-fetch": "^2.6.7",
@@ -196,6 +198,26 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -464,6 +486,33 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/addons-linter/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/addons-linter/node_modules/ajv-merge-patch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-merge-patch/-/ajv-merge-patch-4.1.0.tgz",
+      "integrity": "sha512-0mAYXMSauA8RZ7r+B4+EAOYcZEcO9OK5EiQCR7W7Cv4E44pJj56ZnkKLJ9/PAcOc0dT+LlV9fdDcq2TxVJfOYw==",
+      "dependencies": {
+        "fast-json-patch": "^2.0.6",
+        "json-merge-patch": "^0.2.3"
+      },
+      "peerDependencies": {
+        "ajv": ">=6.0.0"
+      }
+    },
     "node_modules/addons-linter/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -616,6 +665,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/addons-linter/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
     "node_modules/addons-linter/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -692,31 +746,22 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "dev": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+        "json-schema-traverse": "^0.3.0"
       }
     },
-    "node_modules/ajv-merge-patch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-merge-patch/-/ajv-merge-patch-4.1.0.tgz",
-      "integrity": "sha512-0mAYXMSauA8RZ7r+B4+EAOYcZEcO9OK5EiQCR7W7Cv4E44pJj56ZnkKLJ9/PAcOc0dT+LlV9fdDcq2TxVJfOYw==",
-      "dependencies": {
-        "fast-json-patch": "^2.0.6",
-        "json-merge-patch": "^0.2.3"
-      },
-      "peerDependencies": {
-        "ajv": ">=6.0.0"
-      }
+    "node_modules/ajv/node_modules/fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw==",
+      "dev": true
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -1480,6 +1525,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/chai-json-schema-ajv": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/chai-json-schema-ajv/-/chai-json-schema-ajv-5.2.4.tgz",
+      "integrity": "sha512-KjbsSQUZDT4ed/TYmxgoMXU+qTv6KtI+QTzkjVQNNBEc5DAmmKoYwexCOxxTW15tt33muqRwvuq79v52piZZbw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -1644,6 +1698,16 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dependencies": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
       }
     },
     "node_modules/color-convert": {
@@ -2811,6 +2875,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
     "node_modules/espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -3090,7 +3174,7 @@
     "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3443,6 +3527,14 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fx-runner": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.2.0.tgz",
@@ -3691,6 +3783,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/har-validator/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/har-validator/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -4556,7 +4668,7 @@
     "node_modules/json-merge-patch": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-merge-patch/-/json-merge-patch-0.2.3.tgz",
-      "integrity": "sha1-+ixrWvh9p3uuKWalidUuI+2B/kA=",
+      "integrity": "sha512-mjd5eObNGOhWkKCztwVuF25KOzLj2T4TJaWXLBgCQPeoPRJrMxKNgjNBE8sPmXoWRT0WDlo4Itd/gTlFh29TFw==",
       "dependencies": {
         "deep-equal": "^1.0.0"
       }
@@ -4577,9 +4689,10 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==",
+      "dev": true
     },
     "node_modules/json-stable-stringify": {
       "version": "0.0.1",
@@ -6670,12 +6783,13 @@
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8829,6 +8943,24 @@
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -9057,6 +9189,26 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
           "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
         },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-merge-patch": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-merge-patch/-/ajv-merge-patch-4.1.0.tgz",
+          "integrity": "sha512-0mAYXMSauA8RZ7r+B4+EAOYcZEcO9OK5EiQCR7W7Cv4E44pJj56ZnkKLJ9/PAcOc0dT+LlV9fdDcq2TxVJfOYw==",
+          "requires": {
+            "fast-json-patch": "^2.0.6",
+            "json-merge-patch": "^0.2.3"
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -9171,6 +9323,11 @@
             "argparse": "^2.0.1"
           }
         },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9230,23 +9387,23 @@
       "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg=="
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "dev": true,
       "requires": {
-        "fast-deep-equal": "^3.1.1",
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "ajv-merge-patch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-merge-patch/-/ajv-merge-patch-4.1.0.tgz",
-      "integrity": "sha512-0mAYXMSauA8RZ7r+B4+EAOYcZEcO9OK5EiQCR7W7Cv4E44pJj56ZnkKLJ9/PAcOc0dT+LlV9fdDcq2TxVJfOYw==",
-      "requires": {
-        "fast-json-patch": "^2.0.6",
-        "json-merge-patch": "^0.2.3"
+        "json-schema-traverse": "^0.3.0"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw==",
+          "dev": true
+        }
       }
     },
     "ansi-align": {
@@ -9889,6 +10046,12 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-json-schema-ajv": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/chai-json-schema-ajv/-/chai-json-schema-ajv-5.2.4.tgz",
+      "integrity": "sha512-KjbsSQUZDT4ed/TYmxgoMXU+qTv6KtI+QTzkjVQNNBEc5DAmmKoYwexCOxxTW15tt33muqRwvuq79v52piZZbw==",
+      "dev": true
+    },
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -10007,6 +10170,12 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true
     },
     "color-convert": {
       "version": "2.0.1",
@@ -10898,6 +11067,24 @@
         "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
       }
     },
     "eslint-plugin-no-unsanitized": {
@@ -11153,7 +11340,7 @@
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+          "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
         }
       }
     },
@@ -11435,6 +11622,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
+    },
     "fx-runner": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.2.0.tgz",
@@ -11625,6 +11817,24 @@
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
       }
     },
     "has": {
@@ -12228,7 +12438,7 @@
     "json-merge-patch": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-merge-patch/-/json-merge-patch-0.2.3.tgz",
-      "integrity": "sha1-+ixrWvh9p3uuKWalidUuI+2B/kA=",
+      "integrity": "sha512-mjd5eObNGOhWkKCztwVuF25KOzLj2T4TJaWXLBgCQPeoPRJrMxKNgjNBE8sPmXoWRT0WDlo4Itd/gTlFh29TFw==",
       "requires": {
         "deep-equal": "^1.0.0"
       }
@@ -12249,9 +12459,10 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "0.0.1",
@@ -13893,12 +14104,13 @@
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regexp.prototype.flags": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       }
     },
     "regexpp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,8 @@
         "web-ext": "^6.5.0"
       },
       "devDependencies": {
-        "ajv": "^5.5.2",
+        "ajv": "^6.12.6",
         "chai": "^4.3.6",
-        "chai-json-schema-ajv": "^5.2.4",
         "eslint": "^7.6.0",
         "mocha": "^10.1.0",
         "node-fetch": "^2.6.7",
@@ -198,26 +197,6 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -486,21 +465,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/addons-linter/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/addons-linter/node_modules/ajv-merge-patch": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ajv-merge-patch/-/ajv-merge-patch-4.1.0.tgz",
@@ -665,11 +629,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/addons-linter/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
     "node_modules/addons-linter/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -746,22 +705,19 @@
       }
     },
     "node_modules/ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
-      "dev": true,
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dependencies": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "node_modules/ajv/node_modules/fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw==",
-      "dev": true
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -1525,15 +1481,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/chai-json-schema-ajv": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/chai-json-schema-ajv/-/chai-json-schema-ajv-5.2.4.tgz",
-      "integrity": "sha512-KjbsSQUZDT4ed/TYmxgoMXU+qTv6KtI+QTzkjVQNNBEc5DAmmKoYwexCOxxTW15tt33muqRwvuq79v52piZZbw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -1698,16 +1645,6 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dependencies": {
         "mimic-response": "^1.0.0"
-      }
-    },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true,
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
       }
     },
     "node_modules/color-convert": {
@@ -2875,26 +2812,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
     "node_modules/espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -3784,26 +3701,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/har-validator/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/har-validator/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4689,10 +4586,9 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==",
-      "dev": true
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify": {
       "version": "0.0.1",
@@ -8943,24 +8839,6 @@
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -9189,17 +9067,6 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
           "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
         },
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "ajv-merge-patch": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ajv-merge-patch/-/ajv-merge-patch-4.1.0.tgz",
@@ -9323,11 +9190,6 @@
             "argparse": "^2.0.1"
           }
         },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9387,23 +9249,14 @@
       "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg=="
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
-      "dev": true,
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
-      },
-      "dependencies": {
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw==",
-          "dev": true
-        }
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-align": {
@@ -10046,12 +9899,6 @@
         "type-detect": "^4.0.5"
       }
     },
-    "chai-json-schema-ajv": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/chai-json-schema-ajv/-/chai-json-schema-ajv-5.2.4.tgz",
-      "integrity": "sha512-KjbsSQUZDT4ed/TYmxgoMXU+qTv6KtI+QTzkjVQNNBEc5DAmmKoYwexCOxxTW15tt33muqRwvuq79v52piZZbw==",
-      "dev": true
-    },
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -10170,12 +10017,6 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true
     },
     "color-convert": {
       "version": "2.0.1",
@@ -11067,24 +10908,6 @@
         "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        }
       }
     },
     "eslint-plugin-no-unsanitized": {
@@ -11817,24 +11640,6 @@
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        }
       }
     },
     "has": {
@@ -12459,10 +12264,9 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==",
-      "dev": true
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "lint": "echo 'lint not implemented'"
   },
   "devDependencies": {
+    "ajv": "^5.5.2",
     "chai": "^4.3.6",
+    "chai-json-schema-ajv": "^5.2.4",
     "eslint": "^7.6.0",
     "mocha": "^10.1.0",
     "node-fetch": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,8 @@
     "lint": "echo 'lint not implemented'"
   },
   "devDependencies": {
-    "ajv": "^5.5.2",
+    "ajv": "^6.12.6",
     "chai": "^4.3.6",
-    "chai-json-schema-ajv": "^5.2.4",
     "eslint": "^7.6.0",
     "mocha": "^10.1.0",
     "node-fetch": "^2.6.7",

--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -129,11 +129,12 @@ function logDNSResponse(resp, key, transport) {
             parsed = DNS_PACKET.decode(Buffer.from(resp));
         }
         if (parsed) {
+            const hasAnswers = parsed.answers?.length > 0;
             logMessage(
                 `DNS Query for ${key}:\n` +
-                `[Q] ${parsed.questions?.map(({name, type}) => `${name} ${type}`).join(",")}\n` +
-                `%c[A] ${parsed.answers?.map(({name, type, data}) => `${name} ${type} ${stringifyAndTruncate(data)}`).join("\n    ")} `,
-                'color: green;',
+                `[Q] ${parsed.questions?.map(({name, type}) => `${type} ${name}`).join(",")}\n` +
+                `%c[A] ${parsed.answers?.map(({name, type, data}) => `${type} ${name} $${stringifyAndTruncate(data)}`).join("\n    ") || "No answers\n"} `,
+                (hasAnswers ? 'color: green;' : 'color: red;'),
             );
         } else {
             logMessage("Control DNS Query", resp);

--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -4,7 +4,7 @@ const { Buffer } = require("buffer");
 const { v4: uuidv4 } = require("uuid");
 const IP_REGEX = require("ip-regex");
 
-const APEX_DOMAIN_NAME = "dnssec-experiment-moz.net";
+const APEX_DOMAIN_NAME = "dns-study.com";
 const SMIMEA_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15";
 const EXPECTED_FETCH_RESPONSE = "Hello, world!\n";
 

--- a/test/dns-test.test.js
+++ b/test/dns-test.test.js
@@ -224,8 +224,8 @@ describe("dns-test.js", () => {
         it("should send a valid STUDY_MEASUREMENT_COMPLETED ping with the right number of keys", async () => {
             await run();
             /**
-             * The total number of expected entries 2 queries for each item in the COMMON_QUERY config,
-             * and 1 extra (for the webExtA) in non-per-client data
+             * The total number of expected entries 4 queries for each item in the COMMON_QUERY config,
+             * and 1 extra (for the webExtA)
              */
             assertPingSent(STUDY_MEASUREMENT_COMPLETED, ({
                 dnsData,

--- a/test/dnssec-v1.schema.json
+++ b/test/dnssec-v1.schema.json
@@ -1,0 +1,2053 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "mozPipelineMetadata": {
+    "bq_dataset_family": "telemetry",
+    "bq_metadata_format": "telemetry",
+    "bq_table": "dnssec_study_v1_v4"
+  },
+  "properties": {
+    "application": {
+      "additionalProperties": false,
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "buildId": {
+          "pattern": "^[0-9]{10}",
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "displayVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "buildId",
+        "channel",
+        "name",
+        "platformVersion",
+        "version",
+        "vendor",
+        "xpcomAbi"
+      ],
+      "type": "object"
+    },
+    "clientId": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "creationDate": {
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
+      "type": "string"
+    },
+    "environment": {
+      "properties": {
+        "addons": {
+          "properties": {
+            "activeAddons": {
+              "additionalProperties": {
+                "properties": {
+                  "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": "boolean"
+                  },
+                  "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": [
+                      "integer",
+                      "boolean"
+                    ]
+                  },
+                  "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": "boolean"
+                  },
+                  "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
+                    "type": "boolean"
+                  },
+                  "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": "string"
+                  },
+                  "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+                    "type": [
+                      "boolean",
+                      "integer"
+                    ]
+                  },
+                  "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            },
+            "activeExperiment": {
+              "properties": {
+                "branch": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "activeGMPlugins": {
+              "additionalProperties": {
+                "properties": {
+                  "applyBackgroundUpdates": {
+                    "type": [
+                      "integer",
+                      "boolean"
+                    ]
+                  },
+                  "userDisabled": {
+                    "type": "boolean"
+                  },
+                  "version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            },
+            "activePlugins": {
+              "items": {
+                "properties": {
+                  "blocklisted": {
+                    "type": "boolean"
+                  },
+                  "clicktoplay": {
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "mimeTypes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "updateDay": {
+                    "type": "integer"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "persona": {
+              "description": "The id of the active persona (theme).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "theme": {
+              "properties": {
+                "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
+                  "type": "boolean"
+                },
+                "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
+                  "type": [
+                    "boolean",
+                    "integer"
+                  ]
+                },
+                "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
+                  "type": "boolean"
+                },
+                "id": {
+                  "description": "The id of the theme.",
+                  "type": "string"
+                },
+                "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "The theme name, limited to 100 characters.",
+                  "type": "string"
+                },
+                "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
+                  "type": "integer"
+                },
+                "updateDay": {
+                  "description": "The day the theme was last updated.",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
+                  "type": "boolean"
+                },
+                "version": {
+                  "description": "The version of the theme.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "build": {
+          "properties": {
+            "applicationId": {
+              "description": "The application UUID.",
+              "type": "string"
+            },
+            "applicationName": {
+              "description": "The application name.",
+              "type": "string"
+            },
+            "architecture": {
+              "description": "The build architecture for the active build.",
+              "type": "string"
+            },
+            "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
+              "type": "string"
+            },
+            "buildId": {
+              "description": "The build ID/date of the application.",
+              "pattern": "^[0-9]{10}",
+              "type": "string"
+            },
+            "displayVersion": {
+              "description": "The display version of the application.",
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "hotfixVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "platformVersion": {
+              "description": "The version of the XULRunner platform.",
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
+              "type": "boolean"
+            },
+            "vendor": {
+              "description": "The application vendor.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "version": {
+              "description": "The version of the application.",
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "applicationId",
+            "applicationName",
+            "architecture",
+            "buildId",
+            "version",
+            "vendor",
+            "platformVersion",
+            "xpcomAbi"
+          ],
+          "type": "object"
+        },
+        "experiments": {
+          "additionalProperties": {
+            "properties": {
+              "branch": {
+                "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "partner": {
+          "properties": {
+            "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributor": {
+              "description": "The value of the `app.distributor` pref.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "profile": {
+          "properties": {
+            "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
+              "type": "number"
+            },
+            "firstUseDate": {
+              "type": "number"
+            },
+            "isStubProfile": {
+              "type": "boolean"
+            },
+            "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "services": {
+          "properties": {
+            "accountEnabled": {
+              "type": "boolean"
+            },
+            "syncEnabled": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "settings": {
+          "properties": {
+            "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
+              "type": "boolean"
+            },
+            "attribution": {
+              "properties": {
+                "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
+                  "type": "string"
+                },
+                "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
+                  "type": "string"
+                },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
+                "experiment": {
+                  "description": "funnel experiment parameters, see bug 1567339",
+                  "type": "string"
+                },
+                "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
+                  "type": "string"
+                },
+                "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
+                  "type": "string"
+                },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "funnel experiment parameters, see bug 1567339",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
+              "type": "boolean"
+            },
+            "defaultPrivateSearchEngine": {
+              "type": "string"
+            },
+            "defaultPrivateSearchEngineData": {
+              "properties": {
+                "loadPath": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "origin": {
+                  "type": "string"
+                },
+                "submissionURL": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
+              "type": "string"
+            },
+            "defaultSearchEngineData": {
+              "properties": {
+                "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "The name of the default search engine.",
+                  "type": "string"
+                },
+                "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
+                  "type": "string"
+                },
+                "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "e10sCohort": {
+              "type": "string"
+            },
+            "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
+              "type": "boolean"
+            },
+            "e10sMultiProcesses": {
+              "description": "maximum number of processes that will be launched for regular web content",
+              "type": "integer"
+            },
+            "fissionEnabled": {
+              "description": "whether fission is enabled this session, and subframes can load in a different process",
+              "type": "boolean"
+            },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "launcherProcessState": {
+              "type": "integer"
+            },
+            "locale": {
+              "description": "The best locale that the application should be localized to.",
+              "type": "string"
+            },
+            "sandbox": {
+              "properties": {
+                "contentWin32kLockdownState": {
+                  "description": "The status of Win32k Lockdown for Content process.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "searchCohort": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
+              "type": "boolean"
+            },
+            "update": {
+              "properties": {
+                "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
+                  "type": "boolean"
+                },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
+                "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "userPrefs": {
+              "additionalProperties": {
+                "type": [
+                  "boolean",
+                  "string",
+                  "number",
+                  "null"
+                ]
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "system": {
+          "properties": {
+            "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cpu": {
+              "properties": {
+                "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
+                  "maximum": 2048,
+                  "minimum": 1,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
+                  "maximum": 1024,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "isWindowsSMode": {
+                  "description": "Whether or not the system is Windows 10 or 11 in S Mode. S Mode existed prior to us being able to query it, so this is unreliable on Windows versions prior to 1810.",
+                  "type": "boolean"
+                },
+                "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "device": {
+              "properties": {
+                "hardware": {
+                  "type": "string"
+                },
+                "isTablet": {
+                  "type": "boolean"
+                },
+                "manufacturer": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "gfx": {
+              "properties": {
+                "ContentBackend": {
+                  "description": "The name of the content backend.",
+                  "type": "string"
+                },
+                "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "EmbeddedInFirefoxReality": {
+                  "description": "Whether or not Firefox desktop is embedded by Firefox Reality. This is Windows only.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "LowEndMachine": {
+                  "type": "boolean"
+                },
+                "adapters": {
+                  "items": {
+                    "properties": {
+                      "GPUActive": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "RAM": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "deviceID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVersion": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "subsysID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "vendorID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "features": {
+                  "properties": {
+                    "advancedLayers": {
+                      "properties": {
+                        "noConstantBufferOffsetting": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "d2d": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "version": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "d3d11": {
+                      "properties": {
+                        "blacklisted": {
+                          "description": "Indicates whether the d3d11 compositor was blocklisted due to driver bugs. (This field was renamed to blocklisted in bug 1647225).",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "blocklisted": {
+                          "description": "Indicates whether the d3d11 compositor was blocklisted due to driver bugs. (This field replaces blacklisted as of bug 1647225).",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "textureSharing": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "version": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "warp": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "gpuProcess": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "hwCompositing": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "omtp": {
+                      "description": "Indicates whether the off-main-thread painting is enabled.",
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "openglCompositing": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "webrender": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "wrCompositor": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "wrQualified": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "wrSoftware": {
+                      "description": "Indicates whether the software backend to WebRender is enabled.",
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "monitors": {
+                  "items": {
+                    "properties": {
+                      "pseudoDisplay": {
+                        "type": "boolean"
+                      },
+                      "refreshRate": {
+                        "type": "number"
+                      },
+                      "scale": {
+                        "type": "number"
+                      },
+                      "screenHeight": {
+                        "type": "integer"
+                      },
+                      "screenWidth": {
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "hasWinPackageId": {
+              "description": "Is the process running with a package identity (e.g. from an MSIX install)? See bug 1709892. This is Windows only.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "hdd": {
+              "properties": {
+                "binary": {
+                  "properties": {
+                    "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "profile": {
+                  "properties": {
+                    "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "system": {
+                  "properties": {
+                    "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
+              "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "memoryMB": {
+              "description": "The machines amount of RAM.",
+              "type": "number"
+            },
+            "os": {
+              "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
+                  "type": "string"
+                },
+                "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
+                  "type": "string"
+                },
+                "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
+                  "type": "number"
+                },
+                "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
+                  "type": "number"
+                },
+                "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
+                  "type": [
+                    "string"
+                  ]
+                },
+                "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
+                  "type": "number"
+                },
+                "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "sec": {
+              "properties": {
+                "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "build",
+        "partner",
+        "settings",
+        "system"
+      ],
+      "type": "object"
+    },
+    "id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "payload": {
+      "properties": {
+        "dnsAttempts": {
+          "description": "parent object for DNS query attempts for each RRTYPE and socket type",
+          "properties": {
+            "tcpA": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpACD": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpADO": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpADOCD": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpAN": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpDNSKEY": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpDS": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpHTTPS": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpNEWFOUR": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpNEWONE": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpNEWTHREE": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpNEWTWO": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpRRSIG": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpSMIMEA": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpA": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpACD": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpADO": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpADOCD": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpAN": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpAWebExt": {
+              "description": "Number of attempted dns.resolve() calls made using a domain name we control",
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpDNSKEY": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpDS": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpHTTPS": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpNEWFOUR": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpNEWONE": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpNEWTHREE": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpNEWTWO": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpRRSIG": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpSMIMEA": {
+              "minimum": 0,
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "dnsAttemptsPerClient": {
+          "description": "parent object for DNS query attempts for each RRTYPE and socket type",
+          "properties": {
+            "tcpA": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpACD": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpADO": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpADOCD": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpAN": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpDNSKEY": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpDS": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpHTTPS": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpNEWFOUR": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpNEWONE": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpNEWTHREE": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpNEWTWO": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpRRSIG": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpSMIMEA": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpA": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpACD": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpADO": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpADOCD": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpAN": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpAWebExt": {
+              "description": "Number of attempted dns.resolve() calls made using a domain name we control",
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpDNSKEY": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpDS": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpHTTPS": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpNEWFOUR": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpNEWONE": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpNEWTHREE": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpNEWTWO": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpRRSIG": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpSMIMEA": {
+              "minimum": 0,
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "dnsData": {
+          "description": "parent object for DNS responses for each RRTYPE and socket type",
+          "properties": {
+            "tcpA": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpACD": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpADO": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpADOCD": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpAN": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpDNSKEY": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpDS": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpHTTPS": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpNEWFOUR": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpNEWONE": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpNEWTHREE": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpNEWTWO": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpRRSIG": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpSMIMEA": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpA": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpACD": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpADO": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpADOCD": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpAN": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpAWebExt": {
+              "description": "Results from dns.resolve() call made using a domain name we control",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "udpDNSKEY": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpDS": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpHTTPS": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpNEWFOUR": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpNEWONE": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpNEWTHREE": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpNEWTWO": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpRRSIG": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpSMIMEA": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "dnsDataPerClient": {
+          "description": "parent object for DNS responses for each RRTYPE and socket type",
+          "properties": {
+            "tcpA": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpACD": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpADO": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpADOCD": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpAN": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpDNSKEY": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpDS": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpHTTPS": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpNEWFOUR": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpNEWONE": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpNEWTHREE": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpNEWTWO": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpRRSIG": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpSMIMEA": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpA": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpACD": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpADO": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpADOCD": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpAN": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpDNSKEY": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpDS": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpHTTPS": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpNEWFOUR": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpNEWONE": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpNEWTHREE": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpNEWTWO": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpRRSIG": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpSMIMEA": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "dnsQueryErrors": {
+          "description": "A list of queries that failed",
+          "items": {
+            "properties": {
+              "errorAttempt": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "errorRRTYPE": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "errorAttempt": {
+          "minimum": 0,
+          "type": "number"
+        },
+        "errorRRTYPE": {
+          "type": "string"
+        },
+        "hasErrors": {
+          "description": "Does the payload have errors any dns errors included?",
+          "type": "boolean"
+        },
+        "measurementID": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "reason",
+        "measurementID"
+      ],
+      "type": "object"
+    },
+    "type": {
+      "enum": [
+        "dnssec-study-v1"
+      ],
+      "type": "string"
+    },
+    "version": {
+      "maximum": 4,
+      "minimum": 4,
+      "type": "number"
+    }
+  },
+  "required": [
+    "type",
+    "id",
+    "creationDate",
+    "version",
+    "application",
+    "environment",
+    "clientId",
+    "payload"
+  ],
+  "title": "dnssec-study-v1",
+  "type": "object"
+}

--- a/test/dnssec-v1.schema.json
+++ b/test/dnssec-v1.schema.json
@@ -1388,7 +1388,15 @@
               "minimum": 0,
               "type": "number"
             },
+            "tcpA-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "tcpACD": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpACD-U": {
               "minimum": 0,
               "type": "number"
             },
@@ -1396,7 +1404,15 @@
               "minimum": 0,
               "type": "number"
             },
+            "tcpADO-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "tcpADOCD": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpADOCD-U": {
               "minimum": 0,
               "type": "number"
             },
@@ -1404,7 +1420,15 @@
               "minimum": 0,
               "type": "number"
             },
+            "tcpAN-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "tcpDNSKEY": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpDNSKEY-U": {
               "minimum": 0,
               "type": "number"
             },
@@ -1412,7 +1436,15 @@
               "minimum": 0,
               "type": "number"
             },
+            "tcpDS-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "tcpHTTPS": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpHTTPS-U": {
               "minimum": 0,
               "type": "number"
             },
@@ -1420,7 +1452,15 @@
               "minimum": 0,
               "type": "number"
             },
+            "tcpNEWFOUR-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "tcpNEWONE": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "tcpNEWONE-U": {
               "minimum": 0,
               "type": "number"
             },
@@ -1428,11 +1468,20 @@
               "minimum": 0,
               "type": "number"
             },
+            "tcpNEWTHREE-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "tcpNEWTWO": {
               "minimum": 0,
               "type": "number"
             },
+            "tcpNEWTWO-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "tcpRRSIG": {
+              "description": "This property is deprecated and no longer used",
               "minimum": 0,
               "type": "number"
             },
@@ -1440,7 +1489,15 @@
               "minimum": 0,
               "type": "number"
             },
+            "tcpSMIMEA-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "udpA": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpA-U": {
               "minimum": 0,
               "type": "number"
             },
@@ -1448,7 +1505,15 @@
               "minimum": 0,
               "type": "number"
             },
+            "udpACD-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "udpADO": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpADO-U": {
               "minimum": 0,
               "type": "number"
             },
@@ -1456,7 +1521,15 @@
               "minimum": 0,
               "type": "number"
             },
+            "udpADOCD-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "udpAN": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpAN-U": {
               "minimum": 0,
               "type": "number"
             },
@@ -1469,126 +1542,7 @@
               "minimum": 0,
               "type": "number"
             },
-            "udpDS": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpHTTPS": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpNEWFOUR": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpNEWONE": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpNEWTHREE": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpNEWTWO": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpRRSIG": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpSMIMEA": {
-              "minimum": 0,
-              "type": "number"
-            }
-          },
-          "type": "object"
-        },
-        "dnsAttemptsPerClient": {
-          "description": "parent object for DNS query attempts for each RRTYPE and socket type",
-          "properties": {
-            "tcpA": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpACD": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpADO": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpADOCD": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpAN": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpDNSKEY": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpDS": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpHTTPS": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpNEWFOUR": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpNEWONE": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpNEWTHREE": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpNEWTWO": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpRRSIG": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "tcpSMIMEA": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpA": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpACD": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpADO": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpADOCD": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpAN": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpAWebExt": {
-              "description": "Number of attempted dns.resolve() calls made using a domain name we control",
-              "minimum": 0,
-              "type": "number"
-            },
-            "udpDNSKEY": {
+            "udpDNSKEY-U": {
               "minimum": 0,
               "type": "number"
             },
@@ -1596,7 +1550,15 @@
               "minimum": 0,
               "type": "number"
             },
+            "udpDS-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "udpHTTPS": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpHTTPS-U": {
               "minimum": 0,
               "type": "number"
             },
@@ -1604,7 +1566,15 @@
               "minimum": 0,
               "type": "number"
             },
+            "udpNEWFOUR-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "udpNEWONE": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpNEWONE-U": {
               "minimum": 0,
               "type": "number"
             },
@@ -1612,15 +1582,28 @@
               "minimum": 0,
               "type": "number"
             },
+            "udpNEWTHREE-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "udpNEWTWO": {
               "minimum": 0,
               "type": "number"
             },
+            "udpNEWTWO-U": {
+              "minimum": 0,
+              "type": "number"
+            },
             "udpRRSIG": {
+              "description": "This property is deprecated and no longer used",
               "minimum": 0,
               "type": "number"
             },
             "udpSMIMEA": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "udpSMIMEA-U": {
               "minimum": 0,
               "type": "number"
             }
@@ -1636,7 +1619,19 @@
               },
               "type": "array"
             },
+            "tcpA-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "tcpACD": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpACD-U": {
               "items": {
                 "type": "integer"
               },
@@ -1648,7 +1643,19 @@
               },
               "type": "array"
             },
+            "tcpADO-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "tcpADOCD": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpADOCD-U": {
               "items": {
                 "type": "integer"
               },
@@ -1660,7 +1667,19 @@
               },
               "type": "array"
             },
+            "tcpAN-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "tcpDNSKEY": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpDNSKEY-U": {
               "items": {
                 "type": "integer"
               },
@@ -1672,7 +1691,19 @@
               },
               "type": "array"
             },
+            "tcpDS-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "tcpHTTPS": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpHTTPS-U": {
               "items": {
                 "type": "integer"
               },
@@ -1684,7 +1715,19 @@
               },
               "type": "array"
             },
+            "tcpNEWFOUR-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "tcpNEWONE": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "tcpNEWONE-U": {
               "items": {
                 "type": "integer"
               },
@@ -1696,13 +1739,26 @@
               },
               "type": "array"
             },
+            "tcpNEWTHREE-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "tcpNEWTWO": {
               "items": {
                 "type": "integer"
               },
               "type": "array"
             },
+            "tcpNEWTWO-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "tcpRRSIG": {
+              "description": "This property is deprecated and no longer used",
               "items": {
                 "type": "integer"
               },
@@ -1714,7 +1770,19 @@
               },
               "type": "array"
             },
+            "tcpSMIMEA-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "udpA": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpA-U": {
               "items": {
                 "type": "integer"
               },
@@ -1726,7 +1794,19 @@
               },
               "type": "array"
             },
+            "udpACD-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "udpADO": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpADO-U": {
               "items": {
                 "type": "integer"
               },
@@ -1738,7 +1818,19 @@
               },
               "type": "array"
             },
+            "udpADOCD-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "udpAN": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpAN-U": {
               "items": {
                 "type": "integer"
               },
@@ -1757,175 +1849,7 @@
               },
               "type": "array"
             },
-            "udpDS": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpHTTPS": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpNEWFOUR": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpNEWONE": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpNEWTHREE": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpNEWTWO": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpRRSIG": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpSMIMEA": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            }
-          },
-          "type": "object"
-        },
-        "dnsDataPerClient": {
-          "description": "parent object for DNS responses for each RRTYPE and socket type",
-          "properties": {
-            "tcpA": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpACD": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpADO": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpADOCD": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpAN": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpDNSKEY": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpDS": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpHTTPS": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpNEWFOUR": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpNEWONE": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpNEWTHREE": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpNEWTWO": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpRRSIG": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "tcpSMIMEA": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpA": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpACD": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpADO": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpADOCD": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpAN": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "udpDNSKEY": {
+            "udpDNSKEY-U": {
               "items": {
                 "type": "integer"
               },
@@ -1937,7 +1861,19 @@
               },
               "type": "array"
             },
+            "udpDS-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "udpHTTPS": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpHTTPS-U": {
               "items": {
                 "type": "integer"
               },
@@ -1949,7 +1885,19 @@
               },
               "type": "array"
             },
+            "udpNEWFOUR-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "udpNEWONE": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpNEWONE-U": {
               "items": {
                 "type": "integer"
               },
@@ -1961,19 +1909,38 @@
               },
               "type": "array"
             },
+            "udpNEWTHREE-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "udpNEWTWO": {
               "items": {
                 "type": "integer"
               },
               "type": "array"
             },
+            "udpNEWTWO-U": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
             "udpRRSIG": {
+              "description": "This property is deprecated and no longer used",
               "items": {
                 "type": "integer"
               },
               "type": "array"
             },
             "udpSMIMEA": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "udpSMIMEA-U": {
               "items": {
                 "type": "integer"
               },


### PR DESCRIPTION
This PR:
* Updates the structure of the keys so they match what is expected in our data pipeline schema (e.g. `tcpDNSKEY` instead of `tcp-DNSKEYDO`) 
* Adds some tests to validate against the new datapipeline schema
* Sends query-related errors in the final payload, in a `dnsQueryErrors` array rather than in separate pings;
* Makes it a bit easier to see which DNS queries get no answers in logging, for example: 
![image](https://user-images.githubusercontent.com/1455535/203870081-6173369b-c1c2-4530-9dd2-44468afa72a8.png)

See also the data pipeline schema PR: https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/751