### PR TITLE
Additional diagnostic info

### DIFF
--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -446,7 +446,7 @@ function computeDomain(key, {prefix = "", perClientPrefix = "pc"}, perClient) {
     if (perClient) {
         return `${key}-${measurementID}.${perClientPrefix}.${APEX_DOMAIN_NAME}`;
     } else {
-        return `${prefix}.${APEX_DOMAIN_NAME}`;
+        return prefix ? `${prefix}.${APEX_DOMAIN_NAME}` : APEX_DOMAIN_NAME;
     }
 }
 
@@ -633,6 +633,7 @@ module.exports = {
     encodeTCPQuery,
     encodeUDPQuery,
     computeKey,
+    computeDomain,
     TELEMETRY_TYPE,
     STUDY_START,
     STUDY_MEASUREMENT_COMPLETED,

--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -12,7 +12,7 @@ const EXPECTED_FETCH_RESPONSE = "Hello, world!\n";
 // Disable this for now, we don't need it
 const DEFAULT_MAX_SLEEP_TIME = 0;
 
-const RESOLVCONF_ATTEMPTS = 2; // Number of UDP attempts per nameserver. We let TCP handle re-transmissions on its own.
+const RESOLVCONF_ATTEMPTS = 3; // Number of UDP attempts per nameserver. We let TCP handle re-transmissions on its own.
 
 /**
  * @typedef {Object} QueryConfig

--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -552,6 +552,13 @@ async function runMeasurement(details, sleep) {
     let nameservers_ipv4 = await readNameservers();
     await sendQueries(nameservers_ipv4, sleep);
 
+    let addonVersion;
+    try {
+        addonVersion = browser.runtime.getManifest().version
+    } catch (err) {
+        console.error(err);
+    }
+
     // Mark the end of the measurement by sending the DNS responses to telemetry
     let payload = {
         reason: STUDY_MEASUREMENT_COMPLETED,
@@ -559,7 +566,9 @@ async function runMeasurement(details, sleep) {
         dnsData,
         dnsAttempts,
         hasErrors: dnsQueryErrors.length > 0,
-        dnsQueryErrors
+        dnsQueryErrors,
+        addonVersion,
+        apexDomain: APEX_DOMAIN_NAME
     };
 
     // Run the fetch test one more time before submitting our measurements

--- a/test/dns-test.test.js
+++ b/test/dns-test.test.js
@@ -137,6 +137,8 @@ async function setupMeasurementEnvironment(sandbox) {
     browser.telemetry.canUpload.resolves(true);
     browser.captivePortal.getState.resolves("not_captive");
     browser.runtime.getPlatformInfo.resolves({os: "win"});
+    browser.runtime.getManifest.returns({version: "1.2.3"})
+
 
     mockFetch(FETCH_ENDPOINT, EXPECTED_FETCH_RESPONSE);
 
@@ -246,7 +248,9 @@ describe("dns-test.js", () => {
                 dnsAttempts: { "webext-A": 1, "webext-A-U": 1 },
                 dnsData: { "webext-A": FAKE_WEBEXT_RESP, "webext-A-U": FAKE_WEBEXT_RESP },
                 dnsQueryErrors: [],
-                hasErrors: false
+                hasErrors: false,
+                addonVersion: "1.2.3",
+                apexDomain: APEX_DOMAIN_NAME
             };
 
             ALL_KEY_TYPES.forEach(key => {


### PR DESCRIPTION
* Adds add-on version and APEX domain directly from the source code: I don't want to trust the telemetry environment.
* Bumps UDP tries to 3. This is visible in `dnsAttempts`.
* Fixes a bug where `computeDomain` was using `.dns-study.com` instead of `dns-study.com`. I don't think this actually had an impact on the packet we send, but I added some tests anyway.