### PR TITLE
Added v8 experiment test queries in order

### DIFF
--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -467,7 +467,7 @@ async function sendQueries(nameservers_ipv4, sleep) {
 
         { transport: "udp", perClient: false, query: { rrtype: "A", noedns0: true }},
         { transport: "udp", perClient: true, query: { rrtype: "A", noedns0: true }},
-        { key: "webext-A-N-prefix", transport: "udp", perClient: false, query: { prefix: "a-n", rrtype: "A", noedns0: true }},
+        { key: "udp-A-N-prefix", transport: "udp", perClient: false, query: { prefix: "a-n", rrtype: "A", noedns0: true }},
 
         { transport: "udp", perClient: false, query: {rrtype: "NEWONE"}},
         { transport: "udp", perClient: true, query: {rrtype: "NEWONE"}},

--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -76,13 +76,17 @@ var dnsData = {};
 
 var dnsAttempts = {};
 
+var dnsQueryInfo = {};
+
 var dnsQueryErrors = [];
+
 
 // For tests
 function resetState() {
     dnsData = {};
     dnsAttempts = {};
     dnsQueryErrors = [];
+    dnsQueryInfo = {}
 }
 
 function logMessage(...args) {
@@ -252,7 +256,7 @@ const sendDNSQuery = {};
  * used. We make sure that DoH is not used and that A records are queried,
  * rather than AAAA.
  */
-sendDNSQuery.system = async (key, domain) => {
+sendDNSQuery.webext = async (key, domain) => {
     let flags = ["bypass_cache", "disable_ipv6", "disable_trr"];
 
     try {
@@ -413,7 +417,7 @@ async function readNameservers() {
 }
 
 /**
- * @param {"udp"|"tcp"} transport
+ * @param {"udp"|"tcp"|"webext"} transport
  * @param {QueryConfig} args
  * @param {boolean} [perClient]
  * @returns {string}
@@ -450,44 +454,71 @@ function computeDomain(key, {prefix = "", perClientPrefix = "pc"}, perClient) {
     }
 }
 
-function sendQueryFactory(transport, query, nameservers_ipv4, perClient) {
-    const key = computeKey(transport, query, perClient);
-    const domain = computeDomain(key, query, perClient);
-    assert(transport in sendDNSQuery, `${transport} is not a valid transport type`);
-    let sendQuery = sendDNSQuery[transport];
-
-    return () => sendQuery(
-        key,
-        domain,
-        query,
-        nameservers_ipv4
-    );
-}
-
 /**
  * For each RR type that we have a DNS record for, attempt to send queries over
  * UDP and TCP.
  */
 async function sendQueries(nameservers_ipv4, sleep) {
-    // Add a query for our A record that uses the WebExtensions dns.resolve API as a baseline
-    let queries = [];
-    queries.push(() => sendDNSQuery.system("webext-A", APEX_DOMAIN_NAME));
-    queries.push(() => sendDNSQuery.system("webext-A-U", computeDomain("webext-A-U", {rrtype: "A"}, true)));
+    // Add queries for all transports, 1 shared 1 per client
+    let queries = [
+        { transport: "webext", perClient: false, query: { rrtype: "A" }},
+        { transport: "webext", perClient: true, query: { rrtype: "A" }},
+        { key: "webext-A-prefix", transport: "webext", perClient: false, query: { prefix: "a", rrtype: "A" }},
 
-    // Add the remaining queries that use the browser's internal socket APIs
-    for (let query of COMMON_QUERIES) {
-        queries.push(sendQueryFactory("udp", query, nameservers_ipv4));
-        queries.push(sendQueryFactory("tcp", query, nameservers_ipv4));
+        { transport: "udp", perClient: false, query: { rrtype: "A", noedns0: true }},
+        { transport: "udp", perClient: true, query: { rrtype: "A", noedns0: true }},
+        { key: "webext-A-N-prefix", transport: "udp", perClient: false, query: { prefix: "a-n", rrtype: "A", noedns0: true }},
 
-        // Queries where all clients look up a different domain
-        queries.push(sendQueryFactory("udp", query, nameservers_ipv4, true));
-        queries.push(sendQueryFactory("tcp", query, nameservers_ipv4, true));
-    }
+        { transport: "udp", perClient: false, query: {rrtype: "NEWONE"}},
+        { transport: "udp", perClient: true, query: {rrtype: "NEWONE"}},
+
+        [
+            { key: "udp-A-afirst", transport: "udp", perClient: false, query: { prefix: "aaa", rrtype: "A"}},
+            { key: "udp-NEWONE-afirst", transport: "udp", perClient: false, query: { prefix: "aaa", rrtype: "NEWONE"}}
+        ],
+        [
+            { key: "udp-A-afirst-U", transport: "udp", perClient: true, query: { prefix: "aaa", rrtype: "A"}},
+            { key: "udp-NEWONE-afirst-U", transport: "udp", perClient: true, query: { prefix: "aaa", rrtype: "NEWONE"}}
+        ],
+        [
+            { key: "udp-NEWONE-alast", transport: "udp", perClient: false, query: { prefix: "bbb", rrtype: "NEWONE"}},
+            { key: "udp-A-alast", transport: "udp", perClient: false, query: { prefix: "bbb", rrtype: "A"}}
+        ],
+        [
+            { key: "udp-NEWONE-alast-U", transport: "udp", perClient: true, query: { prefix: "bbb", rrtype: "NEWONE"}},
+            { key: "udp-A-alast-U", transport: "udp", perClient: true, query: { prefix: "bbb", rrtype: "A"}}
+        ]
+    ];
 
     // Shuffle the order of the array of queries, and then send the queries
     shuffleArray(queries);
-    for (let sendQuery of queries) {
-        await sendQuery();
+
+    // Flatten the inner arrays
+    queries = queries.flat(1);
+
+    // Reset all query state
+    resetState();
+
+    // Send each query in series
+    for (let [index, {key: customKey, transport, query, perClient}] of queries.entries()) {
+        const key = customKey || computeKey(transport, query, perClient);
+        const domain = computeDomain(key, query, perClient);
+        let sendQuery = sendDNSQuery[transport];
+
+        // Record start time, order
+        dnsQueryInfo[key] = {
+            timestamp: Date.now(),
+            order: index
+        };
+
+        // Actually send the query
+        await sendQuery(
+            key,
+            domain,
+            query,
+            nameservers_ipv4
+        )
+
         if (sleep) {
             await sleepRandom(sleep);
         }
@@ -565,6 +596,7 @@ async function runMeasurement(details, sleep) {
         measurementID,
         dnsData,
         dnsAttempts,
+        dnsQueryInfo,
         hasErrors: dnsQueryErrors.length > 0,
         dnsQueryErrors,
         addonVersion,

--- a/test/dns-test.test.js
+++ b/test/dns-test.test.js
@@ -343,9 +343,9 @@ describe("dns-test.js", () => {
     describe("queries", () => {
         it("should send two control queries, one basic and one to the per-client domain", async () => {
             await run();
-            sinon.assert.calledTwice(sendDNSQuery.system);
-            sinon.assert.calledWithMatch(sendDNSQuery.system, "webext-A", APEX_DOMAIN_NAME);
-            sinon.assert.calledWithMatch(sendDNSQuery.system, "webext-A-U", "webext-A-U-" + FAKE_UUID + ".pc." + APEX_DOMAIN_NAME);
+            sinon.assert.calledTwice(sendDNSQuery.webext);
+            sinon.assert.calledWithMatch(sendDNSQuery.webext, "webext-A", APEX_DOMAIN_NAME);
+            sinon.assert.calledWithMatch(sendDNSQuery.webext, "webext-A-U", "webext-A-U-" + FAKE_UUID + ".pc." + APEX_DOMAIN_NAME);
         });
 
         it("should send the expected tcp and udp queries", async () => {


### PR DESCRIPTION
This PR:
- Adds a `dnsQueryInfo` field to the payload which contains an order and timestamp for each key
- Configures a set of specific queries.

Example payload:
```js
{
"dnsQueryInfo": {
    "udp-A-N-U": {
      "timestamp": 1677089423553,
      "order": 0
    },
    "udp-A-afirst": {
      "timestamp": 1677089423576,
      "order": 1
    },
    "udp-NEWONE-afirst": {
      "timestamp": 1677089423579,
      "order": 2
    },
    "udp-NEWONE-alast": {
      "timestamp": 1677089423593,
      "order": 3
    },
    "udp-A-alast": {
      "timestamp": 1677089423607,
      "order": 4
    },
    "udp-NEWONE-alast-U": {
      "timestamp": 1677089423611,
      "order": 5
    },
    "udp-A-alast-U": {
      "timestamp": 1677089423628,
      "order": 6
    },
    "webext-A": {
      "timestamp": 1677089423655,
      "order": 7
    },
    "webext-A-U": {
      "timestamp": 1677089423656,
      "order": 8
    },
    "udp-NEWONE-U": {
      "timestamp": 1677089423687,
      "order": 9
    },
    "webext-A-prefix": {
      "timestamp": 1677089423702,
      "order": 10
    },
    "udp-A-N-prefix": {
      "timestamp": 1677089423719,
      "order": 11
    },
    "udp-NEWONE": {
      "timestamp": 1677089423726,
      "order": 12
    },
    "udp-A-N": {
      "timestamp": 1677089423742,
      "order": 13
    },
    "udp-A-afirst-U": {
      "timestamp": 1677089423746,
      "order": 14
    },
    "udp-NEWONE-afirst-U": {
      "timestamp": 1677089423770,
      "order": 15
    }
  }
}
```

And all the DNS queries:
```
udp-A-N-U:
[Q] A udp-A-N-U-ca3c3bd2-63d5-4bd8-a726-145b831e7ac8.pc.dnssec-experiment-moz.net

udp-A-afirst:
[Q] A aaa.dnssec-experiment-moz.net

udp-NEWONE-afirst:
NEWONE aaa.dnssec-experiment-moz.net

udp-NEWONE-alast:
NEWONE bbb.dnssec-experiment-moz.net

udp-A-alast:
[Q] A bbb.dnssec-experiment-moz.net

udp-NEWONE-alast-U:
[Q] NEWONE udp-NEWONE-alast-U-ca3c3bd2-63d5-4bd8-a726-145b831e7ac8.pc.dnssec-experiment-moz.net

udp-A-alast-U:
[Q] A udp-A-alast-U-ca3c3bd2-63d5-4bd8-a726-145b831e7ac8.pc.dnssec-experiment-moz.net

webext-A:
dnssec-experiment-moz.net

webext-A-U:
webext-A-U-ca3c3bd2-63d5-4bd8-a726-145b831e7ac8.pc.dnssec-experiment-moz.net

udp-NEWONE-U:
[Q] NEWONE udp-NEWONE-U-ca3c3bd2-63d5-4bd8-a726-145b831e7ac8.pc.dnssec-experiment-moz.net

webext-A-prefix:
a.dnssec-experiment-moz.net

udp-A-N-prefix:
[Q] A a-n.dnssec-experiment-moz.net

udp-NEWONE:
[Q] NEWONE dnssec-experiment-moz.net

udp-A-N:
[Q] A dnssec-experiment-moz.net

udp-A-afirst-U:
[Q] A udp-A-afirst-U-ca3c3bd2-63d5-4bd8-a726-145b831e7ac8.pc.dnssec-experiment-moz.net

udp-NEWONE-afirst-U:
[Q] NEWONE udp-NEWONE-afirst-U-ca3c3bd2-63d5-4bd8-a726-145b831e7ac8.pc.dnssec-experiment-moz.net
```